### PR TITLE
Fix mobile number pad with responsive width

### DIFF
--- a/index.html
+++ b/index.html
@@ -188,10 +188,10 @@
         .number-pad {
         display: grid;
         grid-template-columns: repeat(5, 1fr);
-        gap: 8px;
+        gap: 6px;
         margin: 20px auto;
-        max-width: 280px;
-        padding: 0 10px;
+        max-width: min(90vw, 320px);
+        padding: 0 15px;
         box-sizing: border-box;
         }
 


### PR DESCRIPTION
Uses responsive viewport width (90vw) to prevent horizontal scrolling on mobile devices